### PR TITLE
Use relative import URLs

### DIFF
--- a/_site/components/graduated_meter.js
+++ b/_site/components/graduated_meter.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
+import { html } from "../external/preact-htm-3.1.1.js";
 
 
 function valueToPercent(min, max, value) {

--- a/_site/components/sawmill_about_box.js
+++ b/_site/components/sawmill_about_box.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
+import { html } from "../external/preact-htm-3.1.1.js";
 
 
 const repositoryUrl = "https://github.com/rcowsill/JPEGSawmill";

--- a/_site/components/sawmill_app.js
+++ b/_site/components/sawmill_app.js
@@ -16,10 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
-import { useState } from "/external/hooks.module.js";
-import loadJPEG from "/load_jpeg.js";
-import SawmillUI from "/components/sawmill_ui.js";
+import { html } from "../external/preact-htm-3.1.1.js";
+import { useState } from "../external/hooks.module.js";
+import loadJPEG from "../load_jpeg.js";
+import SawmillUI from "./sawmill_ui.js";
 
 
 function SawmillApp() {

--- a/_site/components/sawmill_brightness_slider.js
+++ b/_site/components/sawmill_brightness_slider.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
+import { html } from "../external/preact-htm-3.1.1.js";
 
 
 function SawmillBrightnessSlider({ brightness, diffView, onBrightnessSet }) {

--- a/_site/components/sawmill_meter.js
+++ b/_site/components/sawmill_meter.js
@@ -16,9 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
-import { useEffect, useRef, useState } from "/external/hooks.module.js";
-import GraduatedMeter from "/components/graduated_meter.js";
+import { html } from "../external/preact-htm-3.1.1.js";
+import { useEffect, useRef, useState } from "../external/hooks.module.js";
+import GraduatedMeter from "./graduated_meter.js";
 
 
 const valueUpdateHz = 10;

--- a/_site/components/sawmill_play_button.js
+++ b/_site/components/sawmill_play_button.js
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
-import SawmillSquareButton from "/components/sawmill_square_button.js";
+import { html } from "../external/preact-htm-3.1.1.js";
+import SawmillSquareButton from "./sawmill_square_button.js";
 
 
 function SawmillPlayButton({ disabled, playback, onPlaybackSet }) {

--- a/_site/components/sawmill_square_button.js
+++ b/_site/components/sawmill_square_button.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
+import { html } from "../external/preact-htm-3.1.1.js";
 
 
 function SawmillSquareButton(props) {

--- a/_site/components/sawmill_toolbar.js
+++ b/_site/components/sawmill_toolbar.js
@@ -16,10 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
-import SawmillBrightnessSlider from "/components/sawmill_brightness_slider.js";
-import SawmillPlayButton from "/components/sawmill_play_button.js";
-import SawmillSquareButton from "/components/sawmill_square_button.js";
+import { html } from "../external/preact-htm-3.1.1.js";
+import SawmillBrightnessSlider from "./sawmill_brightness_slider.js";
+import SawmillPlayButton from "./sawmill_play_button.js";
+import SawmillSquareButton from "./sawmill_square_button.js";
 
 
 const durations = [2, 5, 10, 20, 30, 60];

--- a/_site/components/sawmill_ui.js
+++ b/_site/components/sawmill_ui.js
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
-import { useEffect, useRef, useState } from "/external/hooks.module.js";
-import { useCheckedState, useValueState } from "/hooks/element_state.js";
-import SawmillToolbar from "/components/sawmill_toolbar.js";
-import SawmillViewer from "/components/sawmill_viewer.js";
+import { html } from "../external/preact-htm-3.1.1.js";
+import { useEffect, useRef, useState } from "../external/hooks.module.js";
+import { useCheckedState, useValueState } from "../hooks/element_state.js";
+import SawmillToolbar from "./sawmill_toolbar.js";
+import SawmillViewer from "./sawmill_viewer.js";
 
 
 const endOfImageMarker = Uint8Array.from([0xFF, 0xD9]);

--- a/_site/components/sawmill_viewer.js
+++ b/_site/components/sawmill_viewer.js
@@ -16,10 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
-import useTargetedZoom from "/hooks/targeted_zoom.js";
-import SawmillMeter from "/components/sawmill_meter.js";
-import SawmillViewerFilter from "/components/sawmill_viewer_filter.js";
+import { html } from "../external/preact-htm-3.1.1.js";
+import useTargetedZoom from "../hooks/targeted_zoom.js";
+import SawmillMeter from "./sawmill_meter.js";
+import SawmillViewerFilter from "./sawmill_viewer_filter.js";
 
 
 function getScanSize(scanData, selected) {

--- a/_site/components/sawmill_viewer_filter.js
+++ b/_site/components/sawmill_viewer_filter.js
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { html } from "/external/preact-htm-3.1.1.js";
-import SawmillAboutBox from "/components/sawmill_about_box.js";
+import { html } from "../external/preact-htm-3.1.1.js";
+import SawmillAboutBox from "./sawmill_about_box.js";
 
 
 function getFilterClasses(diffView) {

--- a/_site/hooks/element_state.js
+++ b/_site/hooks/element_state.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useState } from "/external/hooks.module.js";
+import { useCallback, useState } from "../external/hooks.module.js";
 
 
 function useCheckedState(initialValue) {

--- a/_site/hooks/targeted_zoom.js
+++ b/_site/hooks/targeted_zoom.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { useLayoutEffect, useRef } from "/external/hooks.module.js";
+import { useLayoutEffect, useRef } from "../external/hooks.module.js";
 
 
 function getDefaultClientPos(element) {

--- a/_site/jpeg_sawmill.js
+++ b/_site/jpeg_sawmill.js
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import SawmillApp from "/components/sawmill_app.js";
-import { html, render } from "/external/preact-htm-3.1.1.js";
+import SawmillApp from "./components/sawmill_app.js";
+import { html, render } from "./external/preact-htm-3.1.1.js";
 
 (function main() {
   render(html`<${SawmillApp} />`, document.body);

--- a/_site/load_jpeg.js
+++ b/_site/load_jpeg.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import createJPEGInspector from "/dist/jpeg_inspector.js";
+import createJPEGInspector from "./dist/jpeg_inspector.js";
 
 const wasmPageSize = 65536;
 const extraPageCount = 2;


### PR DESCRIPTION
By default, GitHub Pages project site URLs are of the form `https://<org>.github.io/<repo>/`.

Absolute imports would need to start with the repo name to resolve correctly.