### PR TITLE
Fix rotated jpeg size

### DIFF
--- a/_site/components/graduated_meter.js
+++ b/_site/components/graduated_meter.js
@@ -27,6 +27,14 @@ function formatValue(value) {
   return value.toFixed(1);
 }
 
+function getBarClasses(barPercent) {
+  const classes = ["graduated-meter-bar"];
+
+  if (barPercent < 100) { classes.push("clip-bar"); }
+
+  return classes.join(" ");
+}
+
 function renderGraduation(valuePercent) {
   return html`
     <line x1=${valuePercent}% y1="-10%" x2=${valuePercent}% y2=110%></line>
@@ -67,14 +75,14 @@ function GraduatedMeter({ value=0, min=0, max=1, graduations=[], textSettings={}
 
   const barPercent = valueToPercent(min, max, value);
   const barStyles = {
-    "clip-path": `inset(0 ${100 - barPercent}% 0 0)`
+    "--bar-clip-percent": `${100 - barPercent}%`
   };
 
   return html`
     <div class=graduated-meter>
       <${meterGraduations} />
       <${renderLabel} />
-      <div class=graduated-meter-bar style=${(barPercent < 100) ? barStyles : ""}>
+      <div class=${getBarClasses(barPercent)} style=${barStyles}>
         <${meterGraduations} />
         <${renderLabel} />
       </div>

--- a/_site/components/sawmill_ui.js
+++ b/_site/components/sawmill_ui.js
@@ -128,7 +128,7 @@ function handleWheelEvent(e, { zoomLevel }, setZoom) {
 }
 
 
-function SawmillUI({ onFileInputChange, imageWidth, imageHeight, uint8Array, scanEndOffsets }) {
+function SawmillUI({ onFileInputChange, uint8Array, scanEndOffsets }) {
   const [brightness, onBrightnessSet] = useValueState(0);
   const [diffView, onDiffViewSet, setDiffView] = useCheckedState(false);
   const [duration, onDurationSet] = useValueState(10);
@@ -188,7 +188,6 @@ function SawmillUI({ onFileInputChange, imageWidth, imageHeight, uint8Array, sca
     onFileInputChange
   };
 
-  const imageDimensions = { width: imageWidth, height: imageHeight };
   const viewerEvents = {
     onAnimationEnd: (e) => handleAnimationEvent(e, animationIndex, scanData, playbackSetters),
     onWheel: (e) => handleWheelEvent(e, zoom, setZoom)
@@ -197,7 +196,7 @@ function SawmillUI({ onFileInputChange, imageWidth, imageHeight, uint8Array, sca
   return html`
     <div class=sawmill-ui ref=${sawmillUIRef} tabindex=-1 ...${keyboardEvents}>
       <${SawmillToolbar} ...${{ playback, toolbarDisabled, settings, zoomLevels, toolbarEvents }} />
-      <${SawmillViewer} ...${{ playback, scanData, selected, imageDimensions, settings, viewerEvents }} />
+      <${SawmillViewer} ...${{ playback, scanData, selected, settings, viewerEvents }} />
     </div>
   `;
 }

--- a/_site/components/sawmill_viewer.js
+++ b/_site/components/sawmill_viewer.js
@@ -44,7 +44,7 @@ function getViewerStyles(duration) {
 }
 
 
-function SawmillViewer({ playback, scanData=[], selected=0, imageDimensions, settings, viewerEvents }) {
+function SawmillViewer({ playback, scanData=[], selected=0, settings, viewerEvents }) {
   const { duration, scanlines, zoom } = settings;
 
   const viewerProps = {
@@ -72,7 +72,7 @@ function SawmillViewer({ playback, scanData=[], selected=0, imageDimensions, set
     <div ...${viewerProps}>
       <${SawmillMeter} ...${meterProps} />
       <div class=scroll-box ref=${scrollRef} onwheel=${viewerEvents.onWheel}>
-        <${SawmillViewerFilter} ...${{ scanData, selected, imageDimensions, settings }}/>
+        <${SawmillViewerFilter} ...${{ scanData, selected, settings }}/>
       </div>
     </div>
   `;

--- a/_site/components/sawmill_viewer_filter.js
+++ b/_site/components/sawmill_viewer_filter.js
@@ -20,10 +20,11 @@ import { html } from "../external/preact-htm-3.1.1.js";
 import SawmillAboutBox from "./sawmill_about_box.js";
 
 
-function getFilterClasses(diffView) {
+function getFilterClasses(diffView, zoomLevel) {
   const classes = ["filter"];
 
   if (diffView) { classes.push("difference"); }
+  if (zoomLevel > 1) { classes.push("magnified"); }
 
   return classes.join(" ");
 }
@@ -71,9 +72,6 @@ function renderScan(selected, imageDimensions, zoomLevel, scan, index) {
   if (zoomLevel !== 1) {
     imgProps.width = `${zoomLevel * imageDimensions.width}px`;
     imgProps.height = `${zoomLevel * imageDimensions.height}px`;
-    if (zoomLevel < 1) {
-      imgProps.style = { "image-rendering": "revert" };
-    }
   }
 
   return html`
@@ -96,7 +94,7 @@ function SawmillViewerFilter({ scanData, selected, imageDimensions, settings }) 
   const filterStyles = getFilterStyles(brightness, duration, diffView, scanData);
 
   return html`
-    <ol class=${getFilterClasses(diffView)} style=${filterStyles}>
+    <ol class=${getFilterClasses(diffView, zoomLevel)} style=${filterStyles}>
       <li class=${getScanClasses(0, selected)} style="background-color: black;"></li>
       ${scanData.map(renderScan.bind(null, selected, imageDimensions, zoomLevel))}
     </ol>

--- a/_site/components/sawmill_viewer_filter.js
+++ b/_site/components/sawmill_viewer_filter.js
@@ -21,12 +21,13 @@ import SawmillAboutBox from "./sawmill_about_box.js";
 
 
 function getFilterClasses(settings) {
-  const { diffView } = settings;
+  const { brightness, diffView } = settings;
   const { zoomLevel } = settings.zoom;
 
   const classes = ["filter"];
 
   if (diffView) { classes.push("difference"); }
+  if (brightness > 0) { classes.push("brightness"); }
   if (zoomLevel > 1) { classes.push("magnified"); }
   if (zoomLevel !== 1) { classes.push("zoomed"); }
 
@@ -34,17 +35,14 @@ function getFilterClasses(settings) {
 }
 
 function getFilterStyles(imageDimensions, scanData, settings) {
-  const { brightness, duration, diffView } = settings;
+  const { brightness, duration } = settings;
   const { zoomLevel } = settings.zoom;
 
   const lastScan = scanData[scanData.length - 1];
   const styles = {
-    "--anim-byte-duration": `${duration / lastScan.endOffset}s`
+    "--anim-byte-duration": `${duration / lastScan.endOffset}s`,
+    "--diffview-brightness": 2 ** brightness
   };
-
-  if (diffView) {
-    styles.filter = `brightness(${2 ** brightness})`;
-  }
 
   if (zoomLevel !== 1) {
     styles["--zoomed-img-width"] = `${zoomLevel * imageDimensions.width}px`;

--- a/_site/css/jpeg_sawmill.css
+++ b/_site/css/jpeg_sawmill.css
@@ -123,6 +123,10 @@
   list-style: none;
 }
 
+.sawmill-viewer .filter.difference.brightness {
+  filter: brightness(var(--diffview-brightness));
+}
+
 .sawmill-viewer .filter.magnified {
   image-rendering: pixelated;
   image-rendering: crisp-edges;
@@ -247,6 +251,10 @@
 
 .graduated-meter > * {
   grid-area: stack;
+}
+
+.graduated-meter-bar.clip-bar {
+  clip-path: inset(0 var(--bar-clip-percent) 0 0);
 }
 
 .graduated-meter-text {

--- a/_site/css/jpeg_sawmill.css
+++ b/_site/css/jpeg_sawmill.css
@@ -123,13 +123,16 @@
   list-style: none;
 }
 
+.sawmill-viewer .filter.magnified {
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
 .sawmill-viewer .filter > * {
   grid-area: stack;
 }
 
 .sawmill-viewer .scan img {
-  image-rendering: pixelated;
-  image-rendering: crisp-edges;
   display: block;
 }
 

--- a/_site/css/jpeg_sawmill.css
+++ b/_site/css/jpeg_sawmill.css
@@ -128,12 +128,23 @@
   image-rendering: crisp-edges;
 }
 
+.sawmill-viewer .filter.zoomed {
+  width: var(--zoomed-img-width);
+  height: var(--zoomed-img-height);
+}
+
 .sawmill-viewer .filter > * {
   grid-area: stack;
 }
 
 .sawmill-viewer .scan img {
   display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.sawmill-viewer .scan.background {
+  background-color: black;
 }
 
 .sawmill-viewer .scan.previous {

--- a/_site/load_jpeg.js
+++ b/_site/load_jpeg.js
@@ -52,9 +52,7 @@ async function loadJPEG(files, callback) {
 
         console.log(`Inspecting ${file.name}`);
         const rawBuffer = [address, bufferLength];
-        let nextOffset = inspector._getStartOfFrameOffset(...rawBuffer);
-        const imageWidth = inspector._getImageWidth(nextOffset, ...rawBuffer);
-        const imageHeight = inspector._getImageHeight(nextOffset, ...rawBuffer);
+        let nextOffset = 0;
 
         const scanEndOffsets = [];
         for (;;) {
@@ -70,7 +68,7 @@ async function loadJPEG(files, callback) {
         console.log(`Scan end offsets for ${file.name}:`);
         console.log(scanEndOffsets);
 
-        callback({ uint8Array, imageWidth, imageHeight, scanEndOffsets });
+        callback({ uint8Array, scanEndOffsets });
 
         // Free the raw buffer and release the WASM instance
         // TODO: Cache the compiled WASM and reuse

--- a/src/jpeg_inspector.cpp
+++ b/src/jpeg_inspector.cpp
@@ -51,15 +51,6 @@ static const uint16_t MARKER_EOI = 0xFFD9;
 // Scan start marker
 static const uint16_t MARKER_SOS = 0xFFDA;
 
-// Start of Frame marker containing image dimensions
-static const uint16_t MARKER_SOF0 = 0xFFC0;
-static const uint16_t MASK_SOF = 0xFFF0;
-
-// Markers to ignore when matching Start of Frame
-static const uint16_t MARKER_DHT = 0xFFC4;
-static const uint16_t MARKER_JPG = 0xFFC8;
-static const uint16_t MARKER_DAC = 0xFFCC;
-
 // Zero-stuffed "marker" used to escape real 0xFF values in the coded scan data
 static const uint16_t MARKER_IGNORE = 0xFF00;
 
@@ -74,111 +65,16 @@ static const uint16_t MASK_RESTART_MODULUS = 0x0007;
 // Prototypes
 static bool areInputsValid(int32_t startOffset, const uint8_t* buffer, int32_t length);
 static bool isStartOfImagePresent(const uint8_t* buffer, int32_t length);
-static bool isStartOfFramePresent(int32_t startOfFrameOffset, const uint8_t* buffer, int32_t length);
 static bool canGetByte(int32_t offset, int32_t length);
 static uint8_t getByte(int32_t offset, const uint8_t* buffer, int32_t length);
 static bool canGetWord(int32_t offset, int32_t length);
 static uint16_t getWord(int32_t offset, const uint8_t* buffer, int32_t length);
 static int32_t findNextMarker(int32_t offset, const uint8_t* buffer, int32_t length);
 static int32_t skipMarkerSegment(int32_t offset, const uint8_t* buffer, int32_t length);
-static bool isStartOfFrameMarker(uint16_t marker);
 static bool isRestartMarker(uint16_t marker);
 
 
 extern "C" {
-
-int32_t EMSCRIPTEN_KEEPALIVE getStartOfFrameOffset(const uint8_t* buffer, int32_t length)
-{
-    // Start immediately after the SOI marker
-    int32_t offset = 2;
-
-    if (!areInputsValid(offset, buffer, length) || !isStartOfImagePresent(buffer, length))
-    {
-        // If all else fails, skip to the end of the buffer
-        return length;
-    }
-
-    // Find Start of Frame segment
-    while(offset < length)
-    {
-        offset = findNextMarker(offset, buffer, length);
-        if (!canGetWord(offset, length))
-        {
-            offset = length;
-            break;
-        }
-
-        uint16_t marker = getWord(offset, buffer, length);
-        if (isStartOfFrameMarker(marker))
-        {
-            DEBUG_LOG("Start of Frame @ %d", offset);
-
-            break;
-        }
-
-        offset += 2;
-        offset = skipMarkerSegment(offset, buffer, length);
-
-        DEBUG_LOG("  Skipping non-SOF marker %04x @ %d", marker, offset);
-    }
-
-    // Return end offset clamped to length
-    return std::min(offset, length);
-}
-
-uint16_t EMSCRIPTEN_KEEPALIVE getImageWidth(int32_t startOfFrameOffset, const uint8_t* buffer, int32_t length)
-{
-    if (!areInputsValid(startOfFrameOffset, buffer, length) ||
-        !isStartOfImagePresent(buffer, length) ||
-        !isStartOfFramePresent(startOfFrameOffset, buffer, length))
-    {
-        // If all else fails, say the image width is 0
-        return 0;
-    }
-
-    // Check the Start of Frame segment is well-formed
-    const int32_t widthOffset = 5;
-    int32_t offset = startOfFrameOffset + 2;
-    if (!canGetWord(offset, length) || getWord(offset, buffer, length) < 2 + widthOffset)
-    {
-        return 0;
-    }
-
-    offset += widthOffset;
-    if (!canGetWord(offset, length))
-    {
-        return 0;
-    }
-
-    return getWord(offset, buffer, length);
-}
-
-uint16_t EMSCRIPTEN_KEEPALIVE getImageHeight(int32_t startOfFrameOffset, const uint8_t* buffer, int32_t length)
-{
-    if (!areInputsValid(startOfFrameOffset, buffer, length) ||
-        !isStartOfImagePresent(buffer, length) ||
-        !isStartOfFramePresent(startOfFrameOffset, buffer, length))
-    {
-        // If all else fails, say the image height is 0
-        return 0;
-    }
-
-    // Check the Start of Frame segment is well-formed
-    const int32_t heightOffset = 3;
-    int32_t offset = startOfFrameOffset + 2;
-    if (!canGetWord(offset, length) || getWord(offset, buffer, length) < 2 + heightOffset)
-    {
-        return 0;
-    }
-
-    offset += heightOffset;
-    if (!canGetWord(offset, length))
-    {
-        return 0;
-    }
-
-    return getWord(offset, buffer, length);
-}
 
 int32_t EMSCRIPTEN_KEEPALIVE getScanEndOffset(int32_t startOffset, const uint8_t* buffer, int32_t length)
 {
@@ -284,27 +180,6 @@ static bool isStartOfImagePresent(const uint8_t* buffer, int32_t length)
     return true;
 }
 
-static bool isStartOfFramePresent(int32_t startOfFrameOffset, const uint8_t* buffer, int32_t length)
-{
-    // Check for the JPEG SOF marker
-    if (!canGetWord(startOfFrameOffset, length) ||
-        !isStartOfFrameMarker(getWord(startOfFrameOffset, buffer, length)))
-    {
-#ifdef EMSCRIPTEN_DEBUG
-        DEBUG_LOG("Invalid image: No SOF marker");
-        DEBUG_LOG("  canGetWord(%d, %d) = %d", startOfFrameOffset, length, canGetWord(startOfFrameOffset, length));
-
-        if (canGetWord(0, length))
-        {
-            DEBUG_LOG("  getWord(%d, %p, %d) = %04x", startOfFrameOffset, buffer, length, getWord(startOfFrameOffset, buffer, length));
-        }
-#endif // EMSCRIPTEN_DEBUG
-
-        return false;
-    }
-
-    return true;
-}
 
 static bool canGetByte(int32_t offset, int32_t length)
 {
@@ -352,12 +227,6 @@ static int32_t skipMarkerSegment(int32_t offset, const uint8_t* buffer, int32_t 
     }
 
     return offset + getWord(offset, buffer, length);
-}
-
-static bool isStartOfFrameMarker(uint16_t marker)
-{
-    const bool isInSOFMarkerRange = ((marker & MASK_SOF) == MARKER_SOF0);
-    return isInSOFMarkerRange && !(marker == MARKER_DHT || marker == MARKER_JPG || marker == MARKER_DAC);
 }
 
 static bool isRestartMarker(uint16_t marker)

--- a/src/jpeg_inspector.h
+++ b/src/jpeg_inspector.h
@@ -26,10 +26,6 @@
 extern "C" {
 #endif // __cplusplus
 
-extern int32_t getStartOfFrameOffset(const uint8_t* buffer, int32_t length);
-extern uint16_t getImageWidth(int32_t startOfFrameOffset, const uint8_t* buffer, int32_t length);
-extern uint16_t getImageHeight(int32_t startOfFrameOffset, const uint8_t* buffer, int32_t length);
-
 extern int32_t getScanEndOffset(int32_t startOffset, const uint8_t* buffer, int32_t length);
 
 #ifdef __cplusplus

--- a/test/test_jpeg_inspector.cpp
+++ b/test/test_jpeg_inspector.cpp
@@ -31,9 +31,6 @@ LT_END_SUITE(all_tests)
 LT_BEGIN_AUTO_TEST(all_tests, should_ignore_bad_buffer)
     const uint8_t* noBuffer = nullptr;
 
-    LT_ASSERT_EQ(::getStartOfFrameOffset(noBuffer, 0), 0)
-    LT_ASSERT_EQ(::getStartOfFrameOffset(noBuffer, 4), 4)
-
     LT_ASSERT_EQ(::getScanEndOffset(0, noBuffer, 0), 0)
     LT_ASSERT_EQ(::getScanEndOffset(4, noBuffer, 4), 4)
     LT_ASSERT_EQ(::getScanEndOffset(0, noBuffer, 8), 8)
@@ -42,8 +39,6 @@ LT_END_AUTO_TEST(should_ignore_bad_buffer)
 // Should return length if array is empty or start offset is out of bounds
 LT_BEGIN_AUTO_TEST(all_tests, should_ignore_empty_buffer)
     const uint8_t buffer[] = { 0xFF, 0xD8, 0xFF, 0xC2, 0x00, 0x02, 0xFF, 0xDA, 0x00, 0x02, 0xFF, 0xD9 };
-
-    LT_ASSERT_EQ(::getStartOfFrameOffset(buffer, 0), 0)
 
     LT_ASSERT_EQ(::getScanEndOffset(0, buffer, 0), 0)
     LT_ASSERT_EQ(::getScanEndOffset(-1, buffer, COUNT_OF(buffer)), COUNT_OF(buffer))
@@ -55,8 +50,6 @@ LT_END_AUTO_TEST(should_ignore_empty_buffer)
 LT_BEGIN_AUTO_TEST(all_tests, should_ignore_truncated_buffer)
     const uint8_t buffer[] = { 0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x02, 0xFF, 0xC2, 0x00, 0x02 };
 
-    LT_ASSERT_EQ(::getStartOfFrameOffset(buffer, 7), 7)
-
     LT_ASSERT_EQ(::getScanEndOffset(0, buffer, 3), 3)
     LT_ASSERT_EQ(::getScanEndOffset(0, buffer, 7), 7)
 LT_END_AUTO_TEST(should_ignore_truncated_buffer)
@@ -64,8 +57,6 @@ LT_END_AUTO_TEST(should_ignore_truncated_buffer)
 // Should return length for any non-JPEG files
 LT_BEGIN_AUTO_TEST(all_tests, should_ignore_non_jpeg)
     const uint8_t buffer[] = { 0x51, 0x76, 0xF5, 0x43, 0xFF, 0xC2, 0x00, 0x02, 0xFF, 0xDA, 0x00, 0x02, 0xFF, 0xDA, 0x00, 0x02 };
-
-    LT_ASSERT_EQ(::getStartOfFrameOffset(buffer, COUNT_OF(buffer)), COUNT_OF(buffer))
 
     LT_ASSERT_EQ(::getScanEndOffset(0, buffer, COUNT_OF(buffer)), COUNT_OF(buffer))
 LT_END_AUTO_TEST(should_ignore_non_jpeg)
@@ -135,7 +126,6 @@ LT_BEGIN_AUTO_TEST(all_tests, should_scan_real_buffer)
         0x3F, 0x10, 0x20, 0x02, 0xA0, 0x26, 0x6A, 0x2E, 0x96, 0xBA, 0x5A, 0xDD, 0xFD, 0xB7, 0xFF, 0xD9
     };
 
-    const uint16_t expectedStartOfFrameOffset = 0x009E;
     const std::vector<uint16_t> expectedScanEndOffsets =
     {
         0x00F5, 0x011E, 0x0156, 0x018E, 0x01CB, 0x01F6, 0x0205, 0x022E, 0x0259, 0x028E, 0x0290
@@ -143,9 +133,7 @@ LT_BEGIN_AUTO_TEST(all_tests, should_scan_real_buffer)
 
     std::vector<uint16_t> actualScanEndOffsets;
 
-    int32_t offset = ::getStartOfFrameOffset(buffer, COUNT_OF(buffer));
-    LT_ASSERT_EQ(offset, expectedStartOfFrameOffset)
-
+    int32_t offset = 0;
     while (static_cast<uint32_t>(offset) < COUNT_OF(buffer))
     {
         offset = ::getScanEndOffset(offset, buffer, COUNT_OF(buffer));
@@ -156,55 +144,6 @@ LT_BEGIN_AUTO_TEST(all_tests, should_scan_real_buffer)
     LT_ASSERT_EQ(actualScanEndOffsets.size(), expectedScanEndOffsets.size())
     LT_ASSERT_COLLECTIONS_EQ(actualScanEndOffsets.begin(), actualScanEndOffsets.end(), expectedScanEndOffsets.begin())
 LT_END_AUTO_TEST(should_scan_real_buffer)
-
-// Should ignore DHT, JPG and DAC markers
-LT_BEGIN_AUTO_TEST(all_tests, should_ignore_DHT_JPG_DAC)
-    const uint8_t buffer[] =
-    {
-        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x0C, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x01, 0x01, 0x2C,
-        0xFF, 0xC4, 0x00, 0x02, 0xFF, 0xC8, 0x00, 0x02, 0xFF, 0xCC, 0x00, 0x02, 0xFF, 0xC2, 0x00, 0x02
-    };
-
-    int32_t offset = ::getStartOfFrameOffset(buffer, COUNT_OF(buffer));
-    LT_ASSERT_EQ(offset, 0x001C)
-LT_END_AUTO_TEST(should_ignore_DHT_JPG_DAC)
-
-// Should return 0x0 dimensions if Start of Frame segment is truncated
-LT_BEGIN_AUTO_TEST(all_tests, should_ignore_truncated_SOF)
-    const uint8_t buffer[] =
-    {
-        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x01, 0x01, 0x2C,
-        0x01, 0x2C, 0x00, 0x00, 0xFF, 0xC2, 0x00, 0x11, 0x08, 0x00
-    };
-
-    int32_t offset = ::getStartOfFrameOffset(buffer, COUNT_OF(buffer));
-    LT_ASSERT_EQ(offset, 0x0014)
-
-    uint16_t width = ::getImageWidth(offset, buffer, COUNT_OF(buffer));
-    LT_ASSERT_EQ(width, 0)
-
-    uint16_t height = ::getImageHeight(offset, buffer, COUNT_OF(buffer));
-    LT_ASSERT_EQ(height, 0)
-LT_END_AUTO_TEST(should_ignore_truncated_SOF)
-
-// Should return correct dimensions from Start of Frame segment
-LT_BEGIN_AUTO_TEST(all_tests, should_get_image_dimensions)
-    const uint8_t buffer[] =
-    {
-        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x01, 0x01, 0x2C,
-        0x01, 0x2C, 0x00, 0x00, 0xFF, 0xC2, 0x00, 0x11, 0x08, 0x00, 0x20, 0x00, 0x10, 0x03, 0x01, 0x22,
-        0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01
-    };
-
-    int32_t offset = ::getStartOfFrameOffset(buffer, COUNT_OF(buffer));
-    LT_ASSERT_EQ(offset, 0x0014)
-
-    uint16_t width = ::getImageWidth(offset, buffer, COUNT_OF(buffer));
-    LT_ASSERT_EQ(width, 16)
-
-    uint16_t height = ::getImageHeight(offset, buffer, COUNT_OF(buffer));
-    LT_ASSERT_EQ(height, 32)
-LT_END_AUTO_TEST(should_get_image_dimensions)
 
 
 LT_BEGIN_AUTO_TEST_ENV()


### PR DESCRIPTION
JPEGs using EXIF rotation are automatically rotated by the browser, so their width/height may not match the JPEG frame header values.

This PR gets the image size from the last scan's image element (the complete JPEG) after it has finished loading. The naturalWidth/naturalHeight values from the element account for any rotation of the image that is applied during decoding.